### PR TITLE
nut::client::config: preserve OS/package settings of state_dir

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -24,11 +24,31 @@ class nut::client::config {
     mode   => '0644',
   }
 
-  file { $state_dir:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
-    mode   => '0640',
+  case $::osfamily {
+    'Debian': {
+      file { $state_dir:
+        ensure => directory,
+        owner  => 0,
+        group  => $group,
+        mode   => '0770',
+      }
+    }
+    'OpenBSD': {
+      file { $state_dir:
+        ensure => directory,
+        owner  => $user,
+        group  => 'wheel',
+        mode   => '0700',
+      }
+    }
+    default: {
+      file { $state_dir:
+        ensure => directory,
+        owner  => $user,
+        group  => $group,
+        mode   => '0750',
+      }
+    }
   }
 
   case $::osfamily {


### PR DESCRIPTION
On Ubuntu, I noticed that Puppet worked against the upsmon/nut-monitor daemon but changing the owner/perms of the state_dir leading to an unneeded service restart:

```
root@c2d:~# puppet agent -t --tags nut
Info: Using configured environment 'production'
...
Notice: /Stage[main]/Nut::Client::Config/File[/var/run/nut]/owner: owner changed 'root' to 'nut'
Notice: /Stage[main]/Nut::Client::Config/File[/var/run/nut]/mode: mode changed '0770' to '0750'
Info: Class[Nut::Client::Config]: Scheduling refresh of Class[Nut::Common::Service]
Info: Class[Nut::Common::Service]: Scheduling refresh of Service[nut-client]
Notice: /Stage[main]/Nut::Common::Service/Service[nut-client]: Triggered 'refresh' from 1 event
Info: Stage[main]: Unscheduling all events on Stage[main]
Notice: Applied catalog in 1.60 seconds
```

With the PR, the state_dir config done by the OS/package is respected preventing the unneeded service restart.

Note: I only had access to Ubuntu and OpenBSD machines to check the 'normal' state_dir configs.