### PR TITLE
Replace deprecated thrnio/ip module by puppetlabs/stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -70,11 +70,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.0 <5.0.0"
-    },
-    {
-      "name": "thrnio/ip",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=4.25.0 <5.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/types/listen.pp
+++ b/types/listen.pp
@@ -1,2 +1,2 @@
 #
-type Nut::Listen = Struct[{'address' => IP::Address::NoSubnet, Optional['port'] => Integer[0, 65535]}]
+type Nut::Listen = Struct[{'address' => Stdlib::IP::Address::NoSubnet, Optional['port'] => Integer[0, 65535]}]


### PR DESCRIPTION
The module [thrnio/ip](https://forge.puppet.com/modules/thrnio/ip) is deprecated:

https://github.com/thrnio/puppet-ip#deprecated:
> This module has been deprecated and is no longer maintained. Its functionality has been incorporated in puppetlabs/stdlib v4.25.0.

I confirmed that indeed, stdlib version 4.25.0 is when the `Stdlib::IP::Address::NoSubnet` was added. Since the module already depends on the stdlib, I bumped the version requirement and dropped the now deprecated module.