### PR TITLE
Drop old Puppet versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.4.0 <6.0.0"
+      "version_requirement": ">=5.5.10 <7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Bump upper range to cover 6.x.