### PR TITLE
replace usage of has_key with in operator

### DIFF
--- a/manifests/cgi.pp
+++ b/manifests/cgi.pp
@@ -1,10 +1,10 @@
 # Installs the Network UPS Tools (NUT) CGI scripts.
 #
 # @example Declaring the class
-#   include ::nut::cgi
+#   include nut::cgi
 #
 # @example Managing the virtual host configuration elsewhere
-#   class { '::nut::cgi':
+#   class { 'nut::cgi':
 #     manage_vhost => false,
 #   }
 #
@@ -19,18 +19,17 @@
 # @param package_name The name of the package.
 # @param user The unprivileged user used to drop root privileges.
 #
-# @see puppet_classes::nut ::nut
-# @see puppet_defined_types::nut::cgi::ups ::nut::cgi::ups
+# @see puppet_classes::nut nut
+# @see puppet_defined_types::nut::cgi::ups nut::cgi::ups
 class nut::cgi (
-  Hash                    $apache_resources = $::nut::params::apache_resources,
-  Stdlib::Absolutepath    $conf_dir         = $::nut::params::cgi_conf_dir,
-  String                  $group            = $::nut::params::group,
-  Enum['apache', 'httpd'] $http_server      = $::nut::params::http_server,
-  Boolean                 $manage_vhost     = $::nut::params::manage_vhost,
-  String                  $package_name     = $::nut::params::cgi_package_name,
-  String                  $user             = $::nut::params::user,
+  Hash                    $apache_resources = $nut::params::apache_resources,
+  Stdlib::Absolutepath    $conf_dir         = $nut::params::cgi_conf_dir,
+  String                  $group            = $nut::params::group,
+  Enum['apache', 'httpd'] $http_server      = $nut::params::http_server,
+  Boolean                 $manage_vhost     = $nut::params::manage_vhost,
+  String                  $package_name     = $nut::params::cgi_package_name,
+  String                  $user             = $nut::params::user,
 ) inherits nut::params {
-
   contain nut::cgi::install
   contain nut::cgi::config
 

--- a/manifests/cgi/config.pp
+++ b/manifests/cgi/config.pp
@@ -1,9 +1,8 @@
 # @!visibility private
 class nut::cgi::config {
-
-  $conf_dir = $::nut::cgi::conf_dir
-  $group    = $::nut::cgi::group
-  $user     = $::nut::cgi::user
+  $conf_dir = $nut::cgi::conf_dir
+  $group    = $nut::cgi::group
+  $user     = $nut::cgi::user
 
   ensure_resource('group', $group, {
     ensure => present,
@@ -23,7 +22,7 @@ class nut::cgi::config {
     mode   => '0644',
   })
 
-  ::concat { "${conf_dir}/hosts.conf":
+  concat { "${conf_dir}/hosts.conf":
     owner => 0,
     group => 0,
     mode  => '0644',
@@ -38,10 +37,10 @@ class nut::cgi::config {
     content => file('nut/upsset.conf'),
   }
 
-  if $::nut::cgi::manage_vhost {
-    case $::nut::cgi::http_server {
+  if $nut::cgi::manage_vhost {
+    case $nut::cgi::http_server {
       'apache': {
-        $::nut::cgi::apache_resources.each |$type,$resources| {
+        $nut::cgi::apache_resources.each |$type,$resources| {
           $resources.each |$instance,$attributes| { # lint:ignore:variable_scope
             Resource[$type] { # lint:ignore:variable_scope
               $instance: * => $attributes;

--- a/manifests/cgi/install.pp
+++ b/manifests/cgi/install.pp
@@ -1,7 +1,6 @@
 # @!visibility private
 class nut::cgi::install {
-
-  package { $::nut::cgi::package_name:
+  package { $nut::cgi::package_name:
     ensure => present,
   }
 }

--- a/manifests/cgi/ups.pp
+++ b/manifests/cgi/ups.pp
@@ -1,26 +1,25 @@
 # Add a UPS to visualise with the CGI scripts.
 #
 # @example Visualise a UPS
-#   include ::nut::cgi
-#   ::nut::cgi::ups { 'sua1000i@remotehost':
+#   include nut::cgi
+#   nut::cgi::ups { 'sua1000i@remotehost':
 #     description => 'A remote UPS',
 #   }
 #
 # @param description Description of the UPS.
 # @param ups The UPS to visualise.
 #
-# @see puppet_classes::nut::cgi ::nut::cgi
+# @see puppet_classes::nut::cgi nut::cgi
 define nut::cgi::ups (
   String      $description,
   Nut::Device $ups         = $title,
 ) {
-
   if ! defined(Class['nut::cgi']) {
     fail('You must include the nut::cgi base class before using any nut::cgi defined resources')
   }
 
   ::concat::fragment { "nut hosts ${ups}":
     content => "MONITOR ${ups} \"${description}\"\n",
-    target  => "${::nut::cgi::conf_dir}/hosts.conf",
+    target  => "${nut::cgi::conf_dir}/hosts.conf",
   }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,10 +1,10 @@
 # Installs the Network UPS Tools (NUT) client.
 #
 # @example Declaring the class
-#   include ::nut::client
+#   include nut::client
 #
 # @example Using `upssched` for notifications
-#   class { '::nut::client':
+#   class { 'nut::client':
 #     use_upssched => true,
 #   }
 #
@@ -41,38 +41,37 @@
 # @param use_upssched Whether to use `upssched` for notifications or not.
 # @param user The unprivileged user used to drop root privileges.
 #
-# @see puppet_defined_types::nut::client::ups ::nut::client::ups
-# @see puppet_defined_types::nut::client::upssched ::nut::client::upssched
+# @see puppet_defined_types::nut::client::ups nut::client::ups
+# @see puppet_defined_types::nut::client::upssched nut::client::upssched
 class nut::client (
   Optional[Tuple[String, String]]                  $certident      = undef,
   Optional[Stdlib::Absolutepath]                   $certpath       = undef,
   Optional[Boolean]                                $certverify     = undef,
   Optional[Stdlib::Absolutepath]                   $cmdscript      = undef,
-  Stdlib::Absolutepath                             $conf_dir       = $::nut::params::conf_dir,
+  Stdlib::Absolutepath                             $conf_dir       = $nut::params::conf_dir,
   Optional[Integer[0]]                             $deadtime       = undef,
   Optional[Integer[0]]                             $finaldelay     = undef,
   Optional[Boolean]                                $forcessl       = undef,
-  String                                           $group          = $::nut::params::group,
+  String                                           $group          = $nut::params::group,
   Optional[Integer[0]]                             $hostsync       = undef,
   Integer[1]                                       $minsupplies    = 1,
   Optional[Integer[0]]                             $nocommwarntime = undef,
   Boolean                                          $use_upssched   = false,
   Optional[Stdlib::Absolutepath]                   $notifycmd      = $use_upssched ? {
-    true    => $::nut::params::upssched, # lint:ignore:parameter_order
+    true    => $nut::params::upssched, # lint:ignore:parameter_order
     default => undef,
   },
   Optional[Hash[Nut::Event, Tuple[Boolean, 3, 3]]] $notifyflag     = undef,
   Optional[Hash[Nut::Event, String]]               $notifymsg      = undef,
-  String                                           $package_name   = $::nut::params::client_package_name,
+  String                                           $package_name   = $nut::params::client_package_name,
   Optional[Integer[0]]                             $pollfreq       = undef,
   Optional[Integer[0]]                             $pollfreqalert  = undef,
   Optional[Integer[0]]                             $rbwarntime     = undef,
-  String                                           $service_name   = $::nut::params::client_service_name,
-  String                                           $shutdowncmd    = $::nut::params::shutdown_command,
-  Stdlib::Absolutepath                             $state_dir      = $::nut::params::state_dir,
-  String                                           $user           = $::nut::params::user,
+  String                                           $service_name   = $nut::params::client_service_name,
+  String                                           $shutdowncmd    = $nut::params::shutdown_command,
+  Stdlib::Absolutepath                             $state_dir      = $nut::params::state_dir,
+  String                                           $user           = $nut::params::user,
 ) inherits nut::params {
-
   contain nut::client::config
 
   class { 'nut::common':

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,10 +1,9 @@
 # @!visibility private
 class nut::client::config {
-
-  $conf_dir  = $::nut::client::conf_dir
-  $group     = $::nut::client::group
-  $state_dir = $::nut::client::state_dir
-  $user      = $::nut::client::user
+  $conf_dir  = $nut::client::conf_dir
+  $group     = $nut::client::group
+  $state_dir = $nut::client::state_dir
+  $user      = $nut::client::user
 
   group { $group:
     ensure => present,

--- a/manifests/client/ups.pp
+++ b/manifests/client/ups.pp
@@ -1,24 +1,24 @@
 # Add a local or remote UPS to monitor.
 #
 # @example Monitoring a local UPS
-#   include ::nut
-#   ::nut::ups { 'sua1000i':
+#   include nut
+#   nut::ups { 'sua1000i':
 #     driver => 'usbhid-ups',
 #     port   => 'auto',
 #   }
-#   ::nut::user { 'test':
+#   nut::user { 'test':
 #     password => 'password',
 #     upsmon   => 'master',
 #   }
-#   ::nut::client::ups { 'sua1000i@localhost':
+#   nut::client::ups { 'sua1000i@localhost':
 #     user     => 'test',
 #     password => 'password',
 #     type     => 'master',
 #   }
 #
 # @example Monitoring a remote UPS
-#   include ::nut::client
-#   ::nut::client::ups { 'sua1000i@remotehost':
+#   include nut::client
+#   nut::client::ups { 'sua1000i@remotehost':
 #     user     => 'test',
 #     password => 'password',
 #     type     => 'slave',
@@ -33,8 +33,8 @@
 # @param type Is the UPS being monitored attached to the local system or not.
 # @param ups The UPS to monitor.
 #
-# @see puppet_classes::nut::client ::nut::client
-# @see puppet_defined_types::nut::client::upssched ::nut::client::upssched
+# @see puppet_classes::nut::client nut::client
+# @see puppet_defined_types::nut::client::upssched nut::client::upssched
 define nut::client::ups (
   String                                    $user,
   String                                    $password,
@@ -46,13 +46,12 @@ define nut::client::ups (
   },
   Nut::Device                               $ups        = $title,
 ) {
-
   if ! defined(Class['nut::common']) {
     fail('You must include the nut::common base class before using any nut::client defined resources')
   }
 
-  ::concat::fragment { "nut upsmon ${ups}":
+  concat::fragment { "nut upsmon ${ups}":
     content => template("${module_name}/upsmon.ups.erb"),
-    target  => "${::nut::common::conf_dir}/upsmon.conf",
+    target  => "${nut::common::conf_dir}/upsmon.conf",
   }
 }

--- a/manifests/client/upssched.pp
+++ b/manifests/client/upssched.pp
@@ -1,10 +1,10 @@
 # Define actions for `upssched`.
 #
 # @example Configure an action when local UPS has disconnected
-#   class { '::nut::client':
+#   class { 'nut::client':
 #     use_upssched => true,
 #   }
-#   ::nut::client::upssched { 'local ups has disconnected':
+#   nut::client::upssched { 'local ups has disconnected':
 #     args       => [
 #       'upsgone',
 #       10,
@@ -19,23 +19,22 @@
 # @param notifytype The event notification to apply the action to.
 # @param ups The UPS to apply the action to, or "*" to apply to all.
 #
-# @see puppet_classes::nut::client ::nut::client
-# @see puppet_defined_types::nut::client::ups ::nut::client::ups
+# @see puppet_classes::nut::client nut::client
+# @see puppet_defined_types::nut::client::ups nut::client::ups
 define nut::client::upssched (
   Array[Variant[String, Integer], 1]             $args,
   Enum['start-timer', 'cancel-timer', 'execute'] $command,
   Nut::Event                                     $notifytype,
   Variant[Nut::Device, Enum['*']]                $ups,
 ) {
-
   if ! defined(Class['nut::common']) {
     fail('You must include the nut::common base class before using any nut::client defined resources')
   }
 
-  if $::nut::client::use_upssched {
-    ::concat::fragment { "nut upssched ${title}":
+  if $nut::client::use_upssched {
+    concat::fragment { "nut upssched ${title}":
       content => template("${module_name}/upssched.at.erb"),
-      target  => "${::nut::common::conf_dir}/upssched.conf",
+      target  => "${nut::common::conf_dir}/upssched.conf",
     }
   }
 }

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -27,7 +27,6 @@ class nut::common (
   Optional[Integer[0]]                             $pollfreqalert  = undef,
   Optional[Integer[0]]                             $rbwarntime     = undef,
 ) {
-
   contain nut::common::install
   contain nut::common::config
   contain nut::common::service

--- a/manifests/common/config.pp
+++ b/manifests/common/config.pp
@@ -1,43 +1,41 @@
 # @!visibility private
 class nut::common::config {
+  $certident      = $nut::common::certident
+  $certpath       = $nut::common::certpath
+  $certverify     = $nut::common::certverify
+  $cmdscript      = $nut::common::cmdscript
+  $conf_dir       = $nut::common::conf_dir
+  $deadtime       = $nut::common::deadtime
+  $finaldelay     = $nut::common::finaldelay
+  $forcessl       = $nut::common::forcessl
+  $group          = $nut::common::group
+  $hostsync       = $nut::common::hostsync
+  $minsupplies    = $nut::common::minsupplies
+  $nocommwarntime = $nut::common::nocommwarntime
+  $notifycmd      = $nut::common::notifycmd
+  $notifyflag     = $nut::common::notifyflag
+  $notifymsg      = $nut::common::notifymsg
+  $pollfreq       = $nut::common::pollfreq
+  $pollfreqalert  = $nut::common::pollfreqalert
+  $rbwarntime     = $nut::common::rbwarntime
+  $shutdowncmd    = $nut::common::shutdowncmd
+  $state_dir      = $nut::common::state_dir
+  $user           = $nut::common::user
 
-  $certident      = $::nut::common::certident
-  $certpath       = $::nut::common::certpath
-  $certverify     = $::nut::common::certverify
-  $cmdscript      = $::nut::common::cmdscript
-  $conf_dir       = $::nut::common::conf_dir
-  $deadtime       = $::nut::common::deadtime
-  $finaldelay     = $::nut::common::finaldelay
-  $forcessl       = $::nut::common::forcessl
-  $group          = $::nut::common::group
-  $hostsync       = $::nut::common::hostsync
-  $minsupplies    = $::nut::common::minsupplies
-  $nocommwarntime = $::nut::common::nocommwarntime
-  $notifycmd      = $::nut::common::notifycmd
-  $notifyflag     = $::nut::common::notifyflag
-  $notifymsg      = $::nut::common::notifymsg
-  $pollfreq       = $::nut::common::pollfreq
-  $pollfreqalert  = $::nut::common::pollfreqalert
-  $rbwarntime     = $::nut::common::rbwarntime
-  $shutdowncmd    = $::nut::common::shutdowncmd
-  $state_dir      = $::nut::common::state_dir
-  $user           = $::nut::common::user
-
-  ::concat { "${conf_dir}/upsmon.conf":
+  concat { "${conf_dir}/upsmon.conf":
     owner => 0,
     group => $group,
     mode  => '0640',
     warn  => "# !!! Managed by Puppet !!!\n\n",
   }
 
-  ::concat::fragment { 'nut upsmon header':
+  concat::fragment { 'nut upsmon header':
     content => template("${module_name}/upsmon.conf.erb"),
     order   => '01',
     target  => "${conf_dir}/upsmon.conf",
   }
 
-  if $::nut::common::use_upssched {
-
+  if $nut::common::use_upssched {
     file { "${state_dir}/upssched":
       ensure => directory,
       owner  => $user,
@@ -45,20 +43,19 @@ class nut::common::config {
       mode   => '0640',
     }
 
-    ::concat { "${conf_dir}/upssched.conf":
+    concat { "${conf_dir}/upssched.conf":
       owner => 0,
       group => $group,
       mode  => '0640',
       warn  => "# !!! Managed by Puppet !!!\n\n",
     }
 
-    ::concat::fragment { 'nut upssched header':
+    concat::fragment { 'nut upssched header':
       content => template("${module_name}/upssched.conf.erb"),
       order   => '01',
       target  => "${conf_dir}/upssched.conf",
     }
   } else {
-
     file { "${state_dir}/upssched":
       ensure => absent,
       force  => true,

--- a/manifests/common/install.pp
+++ b/manifests/common/install.pp
@@ -1,8 +1,7 @@
 # @!visibility private
 class nut::common::install {
-
-  if $::nut::common::manage_package {
-    package { $::nut::common::package_name:
+  if $nut::common::manage_package {
+    package { $nut::common::package_name:
       ensure => present,
     }
   }

--- a/manifests/common/service.pp
+++ b/manifests/common/service.pp
@@ -1,8 +1,7 @@
 # @!visibility private
 class nut::common::service {
-
-  if $::nut::common::manage_service {
-    service { $::nut::common::service_name:
+  if $nut::common::manage_service {
+    service { $nut::common::service_name:
       ensure     => running,
       enable     => true,
       hasrestart => true,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,24 +1,22 @@
 # @!visibility private
 class nut::config {
-
-  $certfile    = $::nut::certfile
-  $certident   = $::nut::certident
-  $certpath    = $::nut::certpath
-  $certrequest = $::nut::certrequest
-  $conf_dir    = $::nut::conf_dir
-  $group       = $::nut::group
-  $listen      = $::nut::listen
-  $maxage      = $::nut::maxage
-  $maxconn     = $::nut::maxconn
-  $statepath   = $::nut::statepath
-  $user        = $::nut::user
+  $certfile    = $nut::certfile
+  $certident   = $nut::certident
+  $certpath    = $nut::certpath
+  $certrequest = $nut::certrequest
+  $conf_dir    = $nut::conf_dir
+  $group       = $nut::group
+  $listen      = $nut::listen
+  $maxage      = $nut::maxage
+  $maxconn     = $nut::maxconn
+  $statepath   = $nut::statepath
+  $user        = $nut::user
 
   case $facts['os']['family'] {
     'RedHat': {
-
       # So udev rules take effect
       ensure_resource('exec', 'udevadm trigger', {
-        path        => $::path,
+        path        => $facts['path'],
         refreshonly => true,
       })
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,16 @@
 # Installs Network UPS Tools (NUT).
 #
 # @example Declaring the class
-#   include ::nut
+#   include nut
 #
 # @example Listening on local subnet
-#   class { '::nut':
+#   class { 'nut':
 #     listen => [
 #       {
-#         'address' => $::ipaddress_eth0,
+#         'address' => $facts['networking']['interfaces']['eth0']['ip'],
 #       },
 #       {
-#         'address' => $::ipaddress6_eth0,
+#         'address' => $facts['networking']['interfaces']['eth0']['ip6'],
 #       },
 #     ],
 #   }
@@ -57,11 +57,11 @@
 #   `/var/db/nut`.
 # @param user The unprivileged user used to drop root privileges.
 #
-# @see puppet_classes::nut::client ::nut::client
-# @see puppet_defined_types::nut::ups ::nut::ups
-# @see puppet_defined_types::nut::user ::nut::user
-# @see puppet_defined_types::nut::client::ups ::nut::client::ups
-# @see puppet_defined_types::nut::client::upssched ::nut::client::upssched
+# @see puppet_classes::nut::client nut::client
+# @see puppet_defined_types::nut::ups nut::ups
+# @see puppet_defined_types::nut::user nut::user
+# @see puppet_defined_types::nut::client::ups nut::client::ups
+# @see puppet_defined_types::nut::client::upssched nut::client::upssched
 class nut (
   Optional[Stdlib::Absolutepath]                   $certfile              = undef,
   Optional[Tuple[String, String]]                  $certident             = undef,
@@ -75,35 +75,34 @@ class nut (
   Optional[Integer[0]]                             $client_finaldelay     = undef,
   Optional[Boolean]                                $client_forcessl       = undef,
   Optional[Integer[0]]                             $client_hostsync       = undef,
-  Boolean                                          $client_manage_package = $::nut::params::client_manage_package,
-  Boolean                                          $client_manage_service = $::nut::params::client_manage_service,
+  Boolean                                          $client_manage_package = $nut::params::client_manage_package,
+  Boolean                                          $client_manage_service = $nut::params::client_manage_service,
   Integer[1]                                       $client_minsupplies    = 1,
   Optional[Integer[0]]                             $client_nocommwarntime = undef,
   Boolean                                          $client_use_upssched   = false,
   Optional[Stdlib::Absolutepath]                   $client_notifycmd      = $client_use_upssched ? {
-    true    => $::nut::params::upssched, # lint:ignore:parameter_order
+    true    => $nut::params::upssched, # lint:ignore:parameter_order
     default => undef,
   },
   Optional[Hash[Nut::Event, Tuple[Boolean, 3, 3]]] $client_notifyflag     = undef,
   Optional[Hash[Nut::Event, String]]               $client_notifymsg      = undef,
-  String                                           $client_package_name   = $::nut::params::client_package_name,
+  String                                           $client_package_name   = $nut::params::client_package_name,
   Optional[Integer[0]]                             $client_pollfreq       = undef,
   Optional[Integer[0]]                             $client_pollfreqalert  = undef,
   Optional[Integer[0]]                             $client_rbwarntime     = undef,
-  String                                           $client_service_name   = $::nut::params::client_service_name,
-  String                                           $client_shutdowncmd    = $::nut::params::shutdown_command,
-  Stdlib::Absolutepath                             $conf_dir              = $::nut::params::conf_dir,
-  Hash[String, String]                             $driver_packages       = $::nut::params::driver_packages,
-  String                                           $group                 = $::nut::params::group,
+  String                                           $client_service_name   = $nut::params::client_service_name,
+  String                                           $client_shutdowncmd    = $nut::params::shutdown_command,
+  Stdlib::Absolutepath                             $conf_dir              = $nut::params::conf_dir,
+  Hash[String, String]                             $driver_packages       = $nut::params::driver_packages,
+  String                                           $group                 = $nut::params::group,
   Optional[Array[Nut::Listen, 1]]                  $listen                = undef,
   Optional[Integer[1]]                             $maxage                = undef,
   Optional[Integer[1]]                             $maxconn               = undef,
-  String                                           $package_name          = $::nut::params::server_package_name,
-  String                                           $service_name          = $::nut::params::server_service_name,
-  Stdlib::Absolutepath                             $statepath             = $::nut::params::state_dir,
-  String                                           $user                  = $::nut::params::user,
+  String                                           $package_name          = $nut::params::server_package_name,
+  String                                           $service_name          = $nut::params::server_service_name,
+  Stdlib::Absolutepath                             $statepath             = $nut::params::state_dir,
+  String                                           $user                  = $nut::params::user,
 ) inherits nut::params {
-
   contain nut::install
   contain nut::config
   contain nut::service

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,6 @@
 # @!visibility private
 class nut::install {
-
-  package { $::nut::package_name:
+  package { $nut::package_name:
     ensure => present,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,5 @@
 # @!visibility private
 class nut::params {
-
   $shutdown_command    = '/sbin/shutdown -h +0'
 
   case $facts['os']['family'] {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,6 @@
 # @!visibility private
 class nut::service {
-
-  service { $::nut::service_name:
+  service { $nut::service_name:
     ensure     => running,
     enable     => true,
     hasrestart => true,

--- a/manifests/ups.pp
+++ b/manifests/ups.pp
@@ -1,8 +1,8 @@
 # Adds and configures a UPS.
 #
 # @example Adding a USB-connected Smart-UPS 1000i
-#   include ::nut
-#   ::nut::ups { 'sua1000i':
+#   include nut
+#   nut::ups { 'sua1000i':
 #     driver => 'usbhid-ups',
 #     port   => 'auto',
 #   }
@@ -12,29 +12,28 @@
 # @param extra Any additional driver-specific options can be passed here.
 # @param ups The name of the UPS.
 #
-# @see puppet_classes::nut ::nut
-# @see puppet_defined_types::nut::user ::nut::user
+# @see puppet_classes::nut nut
+# @see puppet_defined_types::nut::user nut::user
 define nut::ups (
   String                             $driver,
   Variant[Integer[0, 65535], String] $port,
   Hash[String, Any]                  $extra = {},
   String                             $ups   = $title,
 ) {
-
   if ! defined(Class['nut']) {
     fail('You must include the nut base class before using any nut defined resources')
   }
 
-  ::concat::fragment { "nut ups ${ups}":
+  concat::fragment { "nut ups ${ups}":
     content => template("${module_name}/ups.conf.erb"),
-    target  => "${::nut::conf_dir}/ups.conf",
+    target  => "${nut::conf_dir}/ups.conf",
   }
 
   # Handle SNMP or XML UPS drivers
-  if $driver in $::nut::driver_packages {
-    ensure_packages([$::nut::driver_packages[$driver]])
+  if $driver in $nut::driver_packages {
+    ensure_packages([$nut::driver_packages[$driver]])
 
-    Package[$::nut::driver_packages[$driver]]
-      -> ::Concat::Fragment["nut ups ${ups}"]
+    Package[$nut::driver_packages[$driver]]
+      -> Concat::Fragment["nut ups ${ups}"]
   }
 }

--- a/manifests/ups.pp
+++ b/manifests/ups.pp
@@ -31,7 +31,7 @@ define nut::ups (
   }
 
   # Handle SNMP or XML UPS drivers
-  if has_key($::nut::driver_packages, $driver) {
+  if $driver in $::nut::driver_packages {
     ensure_packages([$::nut::driver_packages[$driver]])
 
     Package[$::nut::driver_packages[$driver]]

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,14 +1,14 @@
 # Configure a user for UPS access.
 #
 # @example Declaring a user
-#   include ::nut
-#   ::nut::user { 'test':
+#   include nut
+#   nut::user { 'test':
 #     password => 'password',
 #   }
 #
 # @example Declaring a upsmon user
-#   include ::nut
-#   ::nut::user { 'monmaster':
+#   include nut
+#   nut::user { 'monmaster':
 #     password => 'secret',
 #     upsmon   => 'master',
 #   }
@@ -19,8 +19,8 @@
 # @param upsmon Set the user to be used by upsmon.
 # @param user The name of the user.
 #
-# @see puppet_classes::nut ::nut
-# @see puppet_defined_types::nut::ups ::nut::ups
+# @see puppet_classes::nut nut
+# @see puppet_defined_types::nut::ups nut::ups
 define nut::user (
   String                            $password,
   Optional[Array[String, 1]]        $actions  = undef,
@@ -28,13 +28,12 @@ define nut::user (
   Optional[Enum['master', 'slave']] $upsmon   = undef,
   String                            $user     = $title,
 ) {
-
   if ! defined(Class['nut']) {
     fail('You must include the nut base class before using any nut defined resources')
   }
 
   ::concat::fragment { "nut user ${user}":
     content => template('nut/upsd.users.erb'),
-    target  => "${::nut::conf_dir}/upsd.users",
+    target  => "${nut::conf_dir}/upsd.users",
   }
 }

--- a/spec/acceptance/nut_cgi_spec.rb
+++ b/spec/acceptance/nut_cgi_spec.rb
@@ -28,7 +28,7 @@ describe 'nut::cgi' do
   it 'works with no errors' do
     pp = <<-EOS
       Package {
-        source => $::osfamily ? {
+        source => $facts['os']['family'] ? {
           # $::architecture fact has gone missing on facter 3.x package currently installed
           'OpenBSD' => "http://ftp.openbsd.org/pub/OpenBSD/${::operatingsystemrelease}/packages/amd64/",
           default   => undef,
@@ -37,7 +37,7 @@ describe 'nut::cgi' do
 
       include ::nut
 
-      case $::osfamily {
+      case $facts['os']['family'] {
         'RedHat': {
           include ::apache
           include ::epel
@@ -92,7 +92,7 @@ describe 'nut::cgi' do
 
       Class['::nut'] ~> Class['::nut::cgi']
 
-      if $::osfamily == 'OpenBSD' {
+      if $facts['os']['family'] == 'OpenBSD' {
 
         file { '/var/www/etc':
           ensure => directory,

--- a/spec/acceptance/nut_client_spec.rb
+++ b/spec/acceptance/nut_client_spec.rb
@@ -40,7 +40,7 @@ describe 'nut::client' do
   it 'works with no errors' do
     pp = <<-EOS
       Package {
-        source => $::osfamily ? {
+        source => $facts['os']['family'] ? {
           # $::architecture fact has gone missing on facter 3.x package currently installed
           'OpenBSD' => "http://ftp.openbsd.org/pub/OpenBSD/${::operatingsystemrelease}/packages/amd64/",
           default   => undef,
@@ -51,7 +51,7 @@ describe 'nut::client' do
         use_upssched => true,
       }
 
-      if $::osfamily == 'RedHat' {
+      if $facts['os']['family'] == 'RedHat' {
         include ::epel
 
         Class['::epel'] -> Class['::nut::client']

--- a/spec/acceptance/nut_spec.rb
+++ b/spec/acceptance/nut_spec.rb
@@ -30,7 +30,7 @@ describe 'nut' do
   it 'works with no errors' do
     pp = <<-EOS
       Package {
-        source => $::osfamily ? {
+        source => $facts['os']['family'] ? {
           # $::architecture fact has gone missing on facter 3.x package currently installed
           'OpenBSD' => "http://ftp.openbsd.org/pub/OpenBSD/${::operatingsystemrelease}/packages/amd64/",
           default   => undef,
@@ -39,7 +39,7 @@ describe 'nut' do
 
       include ::nut
 
-      if $::osfamily == 'RedHat' {
+      if $facts['os']['family'] == 'RedHat' {
         include ::epel
 
         Class['::epel'] -> Class['::nut']


### PR DESCRIPTION
Puppetlabs dropped the has_key function in stdlib with v9.0.0. The attached commit replaces the single usage of has_key with the in operator.

https://forge.puppet.com/modules/puppetlabs/stdlib/changelog#v900---2023-05-30