### PR TITLE
manifests/ups: `has_key()` is deprecated since Puppet 4.0.0

### DIFF
--- a/manifests/ups.pp
+++ b/manifests/ups.pp
@@ -31,7 +31,7 @@ define nut::ups (
   }
 
   # Handle SNMP or XML UPS drivers
-  if has_key($::nut::driver_packages, $driver) {
+  if $driver in $::nut::driver_packages {
     ensure_packages([$::nut::driver_packages[$driver]])
 
     Package[$::nut::driver_packages[$driver]]


### PR DESCRIPTION
It was dropped from [puppetlabs-stdlib v9.0.0](https://github.com/puppetlabs/puppetlabs-stdlib/releases/tag/v9.0.0)