### PR TITLE
nut: mark user password as sensitive

### DIFF
--- a/manifests/client/ups.pp
+++ b/manifests/client/ups.pp
@@ -37,7 +37,7 @@
 # @see puppet_defined_types::nut::client::upssched ::nut::client::upssched
 define nut::client::ups (
   String                                    $user,
-  String                                    $password,
+  Sensitive[String]                         $password,
   Optional[Tuple[String, Boolean, Boolean]] $certhost   = undef,
   Integer[0]                                $powervalue = 1,
   Enum['master', 'slave']                   $type       = $title ? {

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -22,7 +22,7 @@
 # @see puppet_classes::nut ::nut
 # @see puppet_defined_types::nut::ups ::nut::ups
 define nut::user (
-  String                            $password,
+  Sensitive[String]                 $password,
   Optional[Array[String, 1]]        $actions  = undef,
   Optional[Array[String, 1]]        $instcmds = undef,
   Optional[Enum['master', 'slave']] $upsmon   = undef,

--- a/templates/ups.conf.erb
+++ b/templates/ups.conf.erb
@@ -1,6 +1,6 @@
 [<%= @ups %>]
-	driver = <%= @driver %>
-	port = <%= @port %>
+	driver = "<%= @driver %>"
+	port = "<%= @port %>"
 <% @extra.each_pair do |k,v| -%>
 	<%= k %> = "<%= v %>"
 <% end -%>

--- a/templates/ups.conf.erb
+++ b/templates/ups.conf.erb
@@ -1,6 +1,6 @@
 [<%= @ups %>]
-	driver = "<%= @driver %>"
-	port = "<%= @port %>"
+	driver = <%= @driver %>
+	port = <%= @port %>
 <% @extra.each_pair do |k,v| -%>
 	<%= k %> = "<%= v %>"
 <% end -%>

--- a/templates/ups.conf.erb
+++ b/templates/ups.conf.erb
@@ -1,6 +1,10 @@
 [<%= @ups %>]
-	driver = "<%= @driver %>"
-	port = "<%= @port %>"
+ driver = "<%= @driver %>"
+ port = "<%= @port %>"
 <% @extra.each_pair do |k,v| -%>
-	<%= k %> = "<%= v %>"
+<% if v == true -%>
+ <%= k %>
+<% else -%>
+ <%= k %> = "<%= v %>"
+<% end -%>
 <% end -%>

--- a/templates/upsd.users.erb
+++ b/templates/upsd.users.erb
@@ -1,5 +1,5 @@
 [<%= @user %>]
-	password = <%= @password %>
+	password = <%= @password.unwrap %>
 <% if @upsmon -%>
 	upsmon <%= @upsmon %>
 <% else -%>

--- a/templates/upsmon.ups.erb
+++ b/templates/upsmon.ups.erb
@@ -1,4 +1,4 @@
-MONITOR <%= @ups %> <%= @powervalue %> <%= @user %> <%= @password %> <%= @type %>
+MONITOR <%= @ups %> <%= @powervalue %> <%= @user %> <%= @password.unwrap %> <%= @type %>
 <% if @certhost -%>
 CERTHOST "<%= %r{@([^:]+)}.match(@ups)[1] %>" "<%= @certhost[0] %>" "<%= @certhost[1] ? 1 : 0 %>" "<%= @certhost[2] ? 1 : 0 %>"
 <% end -%>


### PR DESCRIPTION
This avoids `puppet agent -t` from showing the plain text password in diffs.